### PR TITLE
Add Support for DynamoDB

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sundog",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sundog",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Wrapper for the JavaScript AWS SDK, powered by Fairmont to give it a functional boost",
   "main": "lib/index.js",
   "files": [

--- a/src/primitives/dynamodb.coffee
+++ b/src/primitives/dynamodb.coffee
@@ -27,7 +27,16 @@ DynamoDB = (_AWS) ->
       ProvisionedThroughput: throughput
 
     {TableDescription}= await db.createTable merge p, options
-    Table
+    TableDescription
+
+  tableUpdate = (name, attributes, throughput, options={}) ->
+    p =
+      TableName: name
+      AttributeDefinitions: attributes
+      ProvisionedThroughput: throughput
+
+    {TableDescription}= await db.updateTable merge p, options
+    TableDescription
 
   tableDel = (name) ->
     try
@@ -130,5 +139,7 @@ DynamoDB = (_AWS) ->
       current
     else
       await scan name, filterEx, options, current
+
+    {tableGet, tableCreate, tableUpdate, tableDel, tableWaitForReady, tableWaitForDeleted, tableEmpty, get, put, update, del, query, scan}
 
 export default DynamoDB

--- a/src/primitives/dynamodb.coffee
+++ b/src/primitives/dynamodb.coffee
@@ -3,9 +3,7 @@
 # This follows the naming convention that methods that work on Tables will be
 # prefixed "table*", whereas item methods will have no prefix.
 
-import {curry, sleep, first, keys, values} from "fairmont"
-import mime from "mime"
-
+import {curry, merge, sleep, empty, cat} from "fairmont"
 import {notFound} from "./utils"
 
 DynamoDB = (_AWS) ->
@@ -14,135 +12,123 @@ DynamoDB = (_AWS) ->
   #===========================================================================
   # Tables
   #===========================================================================
-
   tableGet = (name) ->
     try
-      {Table} = await db.describeTable TableName: name
-      Table
+      {TableDescription} = await db.describeTable TableName: name
+      TableDescription
     catch e
       notFound e
 
-  #===========================================================================
-  # Items
-  #===========================================================================
+  tableCreate = (name, keys, attributes, throughput, options={}) ->
+    p =
+      TableName: name
+      KeySchema: keys
+      AttributeDefinitions: attributes
+      ProvisionedThroughput: throughput
 
-  # Helpers to deal with DynamoDB attribute types
-  toS = (s) -> S: s
-  toN = (n) -> N: n.toString()
-  toB = (b) -> B: b.toString()
-  toSS = (a) -> SS: a
-  toNS = (a) ->
-    a[i] = v.toString for v, i in a
-    NS: a
-  toBS = (a) ->
-    a[i] = v.toString for v, i in a
-    BS: a
-  toM = (m) -> M: m
-  toL = (l) -> L: l
-  toNull = (n) -> NULL: n
-  toBool = (b) -> BOOL: b
+    {TableDescription}= await db.createTable merge p, options
+    Table
 
-  parse = (attributes) ->
-    result = {}
-    for name, typeObj of attributes
-      dataType = first keys typeObj
-      v = first values typeObj
-      switch dataType
-        when "S", "SS", "L", "BOOL" then v
-        when "N" then number v
-        when "B" then v = new Buffer v
-        when "NS" then v[i] = number item for item, i in v
-        when "BS" then v[i] = new Buffer item for item, i in v
-        when "NULL" then v = !v
-        when "M" then v[k] = parse _v for k, _v of v
-        else
-          throw new Error "Unable to parse object for DynamoDB attribute type."
-      result[name] = v
-    result
-
-  get = curry (name, key, options={}) ->
+  tableDel = (name) ->
     try
-      {projectionExpression, consistentRead, returnConsumedCapacity} = options
-      p = {TableName: name, Key: key}
-      p.ProjectionExpression = projectionExpression if projectionExpression
-      p.ConsistentRead = true if consistentRead
-      p.ReturnConsumedCapacity = true if returnConsumedCapacity
-
-      {Item, ConsumedCapacity} = await db.getItem p
-      Item.ConsumedCapacity = ConsumedCapacity
-      Item
+      await db.deleteTable TableName: name
     catch e
       notFound e
 
+  tableWaitForReady = (name) ->
+    while true
+      {TableStatus} = await tableGet name
+      if !TableStatus
+        throw new Error "Cannot find table #{name}"
+      else if TableStatus != "ACTIVE"
+        await sleep 5000
+      else
+        return true
 
-
-
-
-  bucketTouch = (name) ->
-    return true if await bucketExists name
-    await s3.createBucket {Bucket: name}
-    await sleep 15000 # race condition with S3 API.  Wait to be available.
-
-  put = curry (name, key, data, filetype) ->
-    if filetype
-      # here, data is stringified data.
-      content = body = new Buffer data
-    else
-      # here, data is a path to file.
-      filetype = mime.lookup data
-      body = createReadStream data
-      content =
-        if "text" in mime.lookup(data)
-          await read data
-        else
-          await read data, "buffer"
-
-    params =
-      Bucket: name
-      Key: key
-      ContentType: filetype
-      ContentMD5: new Buffer(md5(content), "hex").toString('base64')
-      Body: body
-
-    await s3.putObject params
-
-  get = curry (name, key, encoding="utf8") ->
-    try
-      {Body} = await s3.getObject {Bucket: name, Key: key}
-      Body.toString encoding
-    catch e
-      notFound e
-
-  del = curry (name, key) ->
-    try
-      await s3.deleteObject {Bucket: name, Key: key}
-    catch e
-      notFound e
-
-  bucketDel = (name) ->
-    try
-      await s3.deleteBucket Bucket: name
-    catch e
-      notFound e
-
-  list = curry (name, items=[], marker) ->
-    p = {Bucket: name, MaxKeys: 1000}
-    p.ContinuationToken = marker if marker
-
-    {IsTruncated, Contents, NextContinuationToken} = await s3.listObjectsV2 p
-    if IsTruncated
-      items = cat items, Contents
-      await list name, items, NextContinuationToken
-    else
-      cat items, Contents
+  tableWaitForDeleted = (name) ->
+    while true
+      {TableStatus} = await tableGet name
+      if !TableStatus
+        return true
+      else
+        await sleep 5000
 
   # TODO: make this more efficient by throttling to X connections at once. AWS
   # only supports N requests per second from an account, and I don't want this
   # to violate that limit, but we can do better than one at a time.
-  bucketEmpty = (name) ->
-    items = await list name
-    await del name, i.Key for i in items
+  tableEmpty = (name) ->
+    items = await query name
+    await del name, i for i in items
+
+  #===========================================================================
+  # Items
+  #===========================================================================
+  get = curry (name, key, options={}) ->
+    try
+      {ReturnConsumedCapacity} = options
+      p = {TableName: name, Key: key}
+      {Item, ConsumedCapacity} = await db.getItem merge p, options
+      if ReturnConsumedCapacity then {Item, ConsumedCapacity} else Item
+    catch e
+      notFound e
+
+  put = curry (name, item, options={}) ->
+    p = {TableName: name, Item: item}
+    await db.putItem merge p, options
+
+  update = curry (name, key, data, options={}) ->
+    p = {TableName: name, Key: key, UpdateExpression: data}
+    await db.putItem merge p, options
+
+  del = curry (name, key, options={}) ->
+    p = {TableName: name, Key: key}
+    await db.deleteItem merge p, options
 
 
+  _setupCurrent = ->
+    Items: []
+    Count: 0
+    ScannedCount: 0
+    LastEvaluatedKey: {}
+    ConsumedCapacity: []
+
+  _catCurrent = (current, results) ->
+    {Items, Count, ScannedCount, LastEvaluatedKey, ConsumedCapacity} = results
+    current.Items = cat current.Items, Items
+    current.Count += Count
+    current.ScannedCount += ScannedCount
+    current.LastEvaluatedKey = LastEvaluatedKey
+    current.ConsumedCapacity = current.ConsumedCapacity.push ConsumedCapacity
+    current
+
+
+  query = curry (name, keyEx, filterEx, options={}, current) ->
+    current = _setupCurrent() if !current
+
+    p = {TableName: name}
+    p.KeyConditionExpression = keyEx if keyEx
+    p.FilterExpression = filterEx if filterEx
+    p.ExclusiveStartKey = current.LastEvaluatedKey if current.LastEvaluatedKey
+    results = await db.query merge p, options
+
+    current = _catCurrent current, results
+    if empty(LastEvaluatedKey) || options.Limit
+      current
+    else
+      await query name, keyEx, filterEx, options, current
+
+  scan = curry (name, filterEx, options={}, current) ->
+    current = _setupCurrent() if !current
+
+    p = {TableName: name}
+    p.FilterExpression = filterEx if filterEx
+    p.ExclusiveStartKey = current.LastEvaluatedKey if current.LastEvaluatedKey
+    results = await db.query merge p, options
+
+    current = _catCurrent current, results
+    if empty(LastEvaluatedKey) || options.Limit
+      current
+    else
+      await scan name, filterEx, options, current
 
 export default DynamoDB

--- a/src/primitives/dynamodb.coffee
+++ b/src/primitives/dynamodb.coffee
@@ -1,0 +1,148 @@
+# Primitives for the service DynamoDB.
+# The main entities are Tables and Items.
+# This follows the naming convention that methods that work on Tables will be
+# prefixed "table*", whereas item methods will have no prefix.
+
+import {curry, sleep, first, keys, values} from "fairmont"
+import mime from "mime"
+
+import {notFound} from "./utils"
+
+DynamoDB = (_AWS) ->
+  {DynamoDB: db} = _AWS
+
+  #===========================================================================
+  # Tables
+  #===========================================================================
+
+  tableGet = (name) ->
+    try
+      {Table} = await db.describeTable TableName: name
+      Table
+    catch e
+      notFound e
+
+  #===========================================================================
+  # Items
+  #===========================================================================
+
+  # Helpers to deal with DynamoDB attribute types
+  toS = (s) -> S: s
+  toN = (n) -> N: n.toString()
+  toB = (b) -> B: b.toString()
+  toSS = (a) -> SS: a
+  toNS = (a) ->
+    a[i] = v.toString for v, i in a
+    NS: a
+  toBS = (a) ->
+    a[i] = v.toString for v, i in a
+    BS: a
+  toM = (m) -> M: m
+  toL = (l) -> L: l
+  toNull = (n) -> NULL: n
+  toBool = (b) -> BOOL: b
+
+  parse = (attributes) ->
+    result = {}
+    for name, typeObj of attributes
+      dataType = first keys typeObj
+      v = first values typeObj
+      switch dataType
+        when "S", "SS", "L", "BOOL" then v
+        when "N" then number v
+        when "B" then v = new Buffer v
+        when "NS" then v[i] = number item for item, i in v
+        when "BS" then v[i] = new Buffer item for item, i in v
+        when "NULL" then v = !v
+        when "M" then v[k] = parse _v for k, _v of v
+        else
+          throw new Error "Unable to parse object for DynamoDB attribute type."
+      result[name] = v
+    result
+
+  get = curry (name, key, options={}) ->
+    try
+      {projectionExpression, consistentRead, returnConsumedCapacity} = options
+      p = {TableName: name, Key: key}
+      p.ProjectionExpression = projectionExpression if projectionExpression
+      p.ConsistentRead = true if consistentRead
+      p.ReturnConsumedCapacity = true if returnConsumedCapacity
+
+      {Item, ConsumedCapacity} = await db.getItem p
+      Item.ConsumedCapacity = ConsumedCapacity
+      Item
+    catch e
+      notFound e
+
+
+
+
+
+  bucketTouch = (name) ->
+    return true if await bucketExists name
+    await s3.createBucket {Bucket: name}
+    await sleep 15000 # race condition with S3 API.  Wait to be available.
+
+  put = curry (name, key, data, filetype) ->
+    if filetype
+      # here, data is stringified data.
+      content = body = new Buffer data
+    else
+      # here, data is a path to file.
+      filetype = mime.lookup data
+      body = createReadStream data
+      content =
+        if "text" in mime.lookup(data)
+          await read data
+        else
+          await read data, "buffer"
+
+    params =
+      Bucket: name
+      Key: key
+      ContentType: filetype
+      ContentMD5: new Buffer(md5(content), "hex").toString('base64')
+      Body: body
+
+    await s3.putObject params
+
+  get = curry (name, key, encoding="utf8") ->
+    try
+      {Body} = await s3.getObject {Bucket: name, Key: key}
+      Body.toString encoding
+    catch e
+      notFound e
+
+  del = curry (name, key) ->
+    try
+      await s3.deleteObject {Bucket: name, Key: key}
+    catch e
+      notFound e
+
+  bucketDel = (name) ->
+    try
+      await s3.deleteBucket Bucket: name
+    catch e
+      notFound e
+
+  list = curry (name, items=[], marker) ->
+    p = {Bucket: name, MaxKeys: 1000}
+    p.ContinuationToken = marker if marker
+
+    {IsTruncated, Contents, NextContinuationToken} = await s3.listObjectsV2 p
+    if IsTruncated
+      items = cat items, Contents
+      await list name, items, NextContinuationToken
+    else
+      cat items, Contents
+
+  # TODO: make this more efficient by throttling to X connections at once. AWS
+  # only supports N requests per second from an account, and I don't want this
+  # to violate that limit, but we can do better than one at a time.
+  bucketEmpty = (name) ->
+    items = await list name
+    await del name, i.Key for i in items
+
+
+
+export default DynamoDB

--- a/src/primitives/index.coffee
+++ b/src/primitives/index.coffee
@@ -1,7 +1,9 @@
+import dynamodb from "./dynamodb"
 import s3 from "./s3"
 
 Primitives = (_AWS) ->
+  DynamoDB = dynamodb _AWS
   S3 = s3 _AWS
-  {S3}
+  {DynamoDB, S3}
 
 export default Primitives

--- a/src/primitives/utils.coffee
+++ b/src/primitives/utils.coffee
@@ -1,7 +1,8 @@
 # Some SunDog methods return false when a resource cannot be found instead
 # of throwing the raw AWS error.  In custom cases, that's not always 404.
-notFound = (e, status=404) ->
-  if e.statusCode == status
+notFound = (e, status=404, code) ->
+  if e?.statusCode == status
+    throw e if code && e.code != code
     false
   else
     throw e

--- a/src/primitives/utils.coffee
+++ b/src/primitives/utils.coffee
@@ -1,3 +1,9 @@
-notFound = (e) -> if e.statusCode == 404 then false else throw e
+# Some SunDog methods return false when a resource cannot be found instead
+# of throwing the raw AWS error.  In custom cases, that's not always 404.
+notFound = (e, status=404) ->
+  if e.statusCode == status
+    false
+  else
+    throw e
 
 export {notFound}


### PR DESCRIPTION
This adds a layer of helpers to deal with the AWS service DyanmoDB.  This includes:

- (much like in S3) Table and Item operations Get, Upsert, and Delete
- A new string-based interface for querying tables and indexes
- DyanmoDB type system manipulation, including parsing and wrapping data values.